### PR TITLE
Adapt for Elixir 1.14

### DIFF
--- a/lib/limit_formatter.ex
+++ b/lib/limit_formatter.ex
@@ -14,8 +14,14 @@ defmodule Extrace.LimitFormatter do
         # struct data
         case process_map(term) do
           {_, term} ->
-            infos = Map.to_list(term)
-            Inspect.Any.inspect(term, inspect_as_atom(module), infos, opts)
+            infos = struct_infos(module, term)
+
+            Inspect.Any.inspect(
+              term,
+              Macro.inspect_atom(:literal, module),
+              infos,
+              opts
+            )
 
           _ ->
             Inspect.inspect(term, opts)
@@ -29,15 +35,15 @@ defmodule Extrace.LimitFormatter do
     end
   end
 
+  defp struct_infos(module, map) do
+    for %{field: field} = info <- module.__info__(:struct),
+        field in Map.keys(map),
+        do: info
+  end
+
   def limit_inspect(term, opts) do
     Inspect.inspect(term, opts)
   end
-
-  @spec inspect_as_atom(atom()) :: binary()
-  def inspect_as_atom(true), do: true
-  def inspect_as_atom(false), do: false
-  def inspect_as_atom(nil), do: nil
-  def inspect_as_atom(atom) when is_atom(atom), do: ":#{atom}"
 
   defp process_map(old_term) do
     with true <- :recon_map.is_active(),
@@ -68,7 +74,7 @@ defmodule Extrace.LimitFormatter do
         end
       end
 
-    container_doc(open, map ++ ["..."], close, opts, traverse_fun, separator: sep, break: :strict)
+    container_doc(open, map ++ [:...], close, opts, traverse_fun, separator: sep, break: :strict)
   end
 
   defp inspect_limited_map(map, opts) do

--- a/lib/limit_formatter.ex
+++ b/lib/limit_formatter.ex
@@ -4,7 +4,6 @@ defmodule Extrace.LimitFormatter do
   more details can be found `:recon_map`.
   """
   import Inspect.Algebra
-  alias Code.Identifier
 
   @doc """
   Formatting & Trimming output to selected fields.
@@ -15,7 +14,7 @@ defmodule Extrace.LimitFormatter do
         # struct data
         case process_map(term) do
           {_, term} ->
-            Inspect.Any.inspect(term, Identifier.inspect_as_atom(module), opts)
+            Inspect.Any.inspect(term, inspect_as_atom(module), opts)
 
           _ ->
             Inspect.inspect(term, opts)
@@ -32,6 +31,12 @@ defmodule Extrace.LimitFormatter do
   def limit_inspect(term, opts) do
     Inspect.inspect(term, opts)
   end
+
+  @spec inspect_as_atom(atom()) :: binary()
+  def inspect_as_atom(true), do: true
+  def inspect_as_atom(false), do: false
+  def inspect_as_atom(nil), do: nil
+  def inspect_as_atom(atom) when is_atom(atom), do: ":#{atom}"
 
   defp process_map(old_term) do
     with true <- :recon_map.is_active(),

--- a/lib/limit_formatter.ex
+++ b/lib/limit_formatter.ex
@@ -14,7 +14,8 @@ defmodule Extrace.LimitFormatter do
         # struct data
         case process_map(term) do
           {_, term} ->
-            Inspect.Any.inspect(term, inspect_as_atom(module), opts)
+            infos = Map.to_list(term)
+            Inspect.Any.inspect(term, inspect_as_atom(module), infos, opts)
 
           _ ->
             Inspect.inspect(term, opts)

--- a/mix.exs
+++ b/mix.exs
@@ -2,13 +2,13 @@ defmodule Extrace.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/redink/extrace"
-  @version "0.3.1"
+  @version "0.4.0"
 
   def project do
     [
       app: :extrace,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.14.0",
       start_permanent: Mix.env() == :prod,
       package: package(),
       deps: deps(),

--- a/test/extrace_test.exs
+++ b/test/extrace_test.exs
@@ -56,7 +56,7 @@ defmodule ExtraceTest do
     map_set = MapSet.new()
 
     assert format({:trace_ts, pid(0, 1, 2), :return_from, {MapSet, :new, 0}, map_set, ts}) ==
-             '\n#{format_timestamp(ts)} <0.1.2> MapSet.new/0 --> #MapSet<[]>\n'
+             '\n#{format_timestamp(ts)} <0.1.2> MapSet.new/0 --> MapSet.new([])\n'
   end
 
   test "format/1 for :return_to" do


### PR DESCRIPTION
This library uses several functions of Elixir's internal modules that has changed across versions. I adapted the incompatible changes from Elixir 1.14 back to this library.

Ideally it would be best to remove the calls to the internal modules completely, but I do not have the sufficient knowledge to do it here.