### PR TITLE
Added arg matcher shortcut :return

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:extrace, "~> 0.3.0"}
+    {:extrace, "~> 0.5.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ end
 Set point:
 
 ```elixir
-iex> Extrace.calls([{Enum, :take_random, fn _ -> :return end}, {Enum, :count, fn _ -> :return end}], 100, [scope: :local])
+iex> Extrace.calls([{Enum, :take_random, :return}, {Enum, :count, :return}], 100, [scope: :local])
 4
 ```
 
-Note that the functions to be traced (`:take_random` and `:count` in the example above) can only be private if `scope: :local` is set.
+Note that the functions to be traced (`:take_random` and `:count` in the example above) can be private if `scope: :local` is set.
 
 One function executed:
 
@@ -72,6 +72,24 @@ iex(4)> Enum.count([1,2,3,4])
 18:42:27.383667 <0.183.0> Enum.count([1, 2, 3, 4])
 
 18:42:27.383795 <0.183.0> Enum.count/1 --> 4
+```
+
+We can match the argument list in a specific manner. For example, we can trace
+`Enum.at/2` with the first argument (the enumerable) that has `1` as its
+initial element:
+
+```elixir
+iex(5)> Extrace.calls({Enum, :at, fn [x, _] when hd(x) == 1 -> :return end}, 2)
+2
+iex(6)> Enum.at([2, 3, 4], 1)
+3
+iex(7)> Enum.at([1, 7, 5], 1)
+7
+
+14:01:22.321329 <0.111.0> Enum.at([1, 7, 5], 1)
+
+14:01:22.321653 <0.111.0> Enum.at/2 --> 7
+Recon tracer rate limit tripped.
 ```
 
 ## Copyright and License

--- a/lib/extrace.ex
+++ b/lib/extrace.ex
@@ -527,6 +527,6 @@ defmodule Extrace do
 
   @doc false
   defp inspect_opts() do
-    Application.get_env(:extrace, :inspect_opts, [pretty: true])
+    Application.get_env(:extrace, :inspect_opts, pretty: true)
   end
 end

--- a/lib/extrace.ex
+++ b/lib/extrace.ex
@@ -197,7 +197,7 @@ defmodule Extrace do
 
   @type mod :: :_ | module
   @type f :: :_ | atom
-  @type args :: :_ | :return_trace | 0..255 | matchspec | shellfun
+  @type args :: :_ | :return | 0..255 | matchspec | shellfun
   @type tspec :: {mod, f, args}
   @type max :: max_traces | max_rate
   @type num_matches :: non_neg_integer
@@ -334,6 +334,10 @@ defmodule Extrace do
   @spec to_erl_tspec(tspec) :: tspec
   def to_erl_tspec({mod, fun, shellfun}) when is_function(shellfun) do
     {mod, fun, fun_to_match_spec(shellfun)}
+  end
+
+  def to_erl_tspec({mod, fun, :return}) do
+    {mod, fun, :return_trace}
   end
 
   def to_erl_tspec({_mod, _fun, _arity_or_matchspec} = tspec) do
@@ -523,6 +527,6 @@ defmodule Extrace do
 
   @doc false
   defp inspect_opts() do
-    Application.get_env(:extrace, :inspect_opts, [pretty: true])
+    Application.get_env(:extrace, :inspect_opts, [pretty: true, limit: 50])
   end
 end

--- a/lib/extrace.ex
+++ b/lib/extrace.ex
@@ -527,6 +527,6 @@ defmodule Extrace do
 
   @doc false
   defp inspect_opts() do
-    Application.get_env(:extrace, :inspect_opts, [pretty: true, limit: 50])
+    Application.get_env(:extrace, :inspect_opts, [pretty: true])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Extrace.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/redink/extrace"
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [

--- a/test/extrace_test.exs
+++ b/test/extrace_test.exs
@@ -40,7 +40,7 @@ defmodule ExtraceTest do
              {:trace_ts, pid(0, 1, 2), :return_from, {IO, :inspect, 1}, %{test: true, a: 1, b: 2},
               ts}
            ) ==
-             '\n#{format_timestamp(ts)} <0.1.2> IO.inspect/1 --> %{a: 1, b: 2, ...}\n'
+             '\n#{format_timestamp(ts)} <0.1.2> IO.inspect/1 --> %{a: 1, b: 2, test: true}\n'
 
     assert format(
              {:trace_ts, pid(0, 1, 2), :return_from, {IO, :inspect, 1}, %{a: 1, b: 2, c: 3}, ts}
@@ -51,7 +51,7 @@ defmodule ExtraceTest do
 
     # Format an Struct data
     assert format({:trace_ts, pid(0, 1, 2), :return_from, {IO, :inspect, 1}, %Inspect.Opts{}, ts}) ==
-             '\n#{format_timestamp(ts)} <0.1.2> IO.inspect/1 --> #Inspect.Opts<limit: 50, width: 80, ...>\n'
+             '\n#{format_timestamp(ts)} <0.1.2> IO.inspect/1 --> %Inspect.Opts{\n  base: :decimal,\n  binaries: :infer,\n  char_lists: :infer,\n  charlists: :infer,\n  custom_options: [],\n  inspect_fun: &Inspect.inspect/2,\n  limit: 50,\n  pretty: false,\n  printable_limit: 4096,\n  safe: true,\n  structs: true,\n  syntax_colors: [],\n  width: 80\n}\n'
 
     map_set = MapSet.new()
 

--- a/test/extrace_test.exs
+++ b/test/extrace_test.exs
@@ -15,6 +15,7 @@ defmodule ExtraceTest do
     matchspec = [{[:item, :_], [], [{:return_trace}]}]
 
     assert to_erl_tspec({:queue, :in, shellfun}) == {:queue, :in, matchspec}
+    assert to_erl_tspec({:queue, :in, :return}) == {:queue, :in, :return_trace}
   end
 
   test "format/1 for :call" do


### PR DESCRIPTION
Hey Tao总,

As we have somewhat replaced `:return_trace` in `:recon_trace` with `:return`, I think it's good to have:
```elixir
Extrace.calls({Mod, :fun, :return}, 10)
```
To trace the return too, as a shortcut to following:
```
Extrace.calls({Mod, :fun, fn _ -> :return end}, 10)

# or (here `:return_trace` is hidden from users of Extrace by design?)
Extrace.calls({Mod, :fun, :return_trace}, 10)
```

Ideas?